### PR TITLE
add gitlab private and public deps support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ user>
 
 With a namespace they are searched for using Clojure's normal namespace resolution machinery. The current directory is on the load path by default.
 
-```
+```clojure
 $ cat tasks.clj
 (ns tasks)
 
@@ -59,7 +59,7 @@ $ nos tasks/build
 
 Command line arguments are parsed as EDN passed to the function.
 
-```
+```clojure
 $ cat tasks.clj
 (ns tasks)
 
@@ -74,7 +74,7 @@ $ nos tasks/build true
 
 Your entry namespace can also set up your classpath, load assemblies, and eventually manage dependencies.  
 
-```
+```clojure
 $ cat tasks.clj
 (assembly-load-from "assemblies/SomeLib.dll")
 (ns tasks
@@ -112,7 +112,19 @@ For example, the [MAGIC project's](https://github.com/nasser/magic) [`project.ed
 ```
 
 #### `:github`
-Github sources clones a whole repository as a dependency. `name` takes the form `username/repository` and `version` is anything that refers to a commit, like a branch name, a tag, or a full commit hash.
+Github sources clone a whole repository as a dependency. `name` takes the form `username/repository` and `version` is anything that refers to a commit, like a branch name, a tag, or a full commit hash.
+
+#### `:gitlab`
+Gitlab sources clone a whole repository as a dependency. `name` takes the form `username/repository` and `version` is the branch name. The `sha` and the `project-id` must be provided as well for public and private repository. For private repository, `domain` and access `token` are required as well. Here is an example of a gitlab private dependency:
+
+```clojure
+[:gitlab loic/my-lib "master"
+ :paths ["src"]
+ :sha "08f78dec3po452272cr2d2eb2ea85778ff2ce1d6"
+ :token "xxxxxxxxxxxxx"
+ :domain "dev.hello.sg"
+ :project-id "777"]
+```
 
 The root of the repository is the only directory added to the load path by default, but you can specify subdirectories by adding `:paths` followed by a vector of strings to the coordinate.
 

--- a/nostrand/core.clj
+++ b/nostrand/core.clj
@@ -1,10 +1,11 @@
 (ns
-  ^{:author "Ramsey Nasser"
-    :doc "Core nostrand API containing load path, assemblies, and dependency functions."}
-  nostrand.core
+    ^{:author "Ramsey Nasser"
+      :doc "Core nostrand API containing load path, assemblies, and dependency functions."}
+    nostrand.core
   (:require [clojure.string :as string]
             [nostrand.deps :as deps]
             nostrand.deps.github
+            nostrand.deps.gitlab
             nostrand.deps.maven
             nostrand.deps.nuget)
   (:import [System.IO Path File]))

--- a/nostrand/deps/gitlab.clj
+++ b/nostrand/deps/gitlab.clj
@@ -1,0 +1,41 @@
+(assembly-load-with-partial-name "System.IO.Compression.FileSystem")
+(assembly-load-with-partial-name "System.IO.Compression")
+
+(ns nostrand.deps.gitlab
+  (:import [System.IO.Compression ZipFile]
+           [System.IO Directory File]
+           [System.Net WebClient])
+  (:require [nostrand.deps :refer [acquire! paths]]
+            [nostrand.deps.shell :refer [in-dir]]))
+
+(defn build-uri
+  "Create the proper uri to fetch the remote lib."
+  [branch token domain project-id]
+  (if token
+    ;; private project : needs token access and domain
+    (str "https://" domain "/api/v4/projects/" project-id "/repository/archive.zip?ref=" branch "&access_token=" token)
+    ;; public project
+    (str "https://gitlab.com/api/v4/projects/" project-id "/repository/archive.zip?ref=" branch)))
+
+(defmethod acquire! :gitlab
+  [{:keys [root] :as opts}
+   [head repo branch & {:keys [sha token domain project-id]}]]
+  (let [gitlab-user (namespace repo)
+        gitlab-repo (name repo)
+        url (build-uri branch token domain project-id)
+        prefix (str root "/" (name head) "/" gitlab-user)
+        temp-name (str (gensym (str gitlab-user "-" gitlab-repo)) ".zip")]
+    (when-not (Directory/Exists (str prefix "/" gitlab-repo "-" branch "-" sha))
+      (in-dir prefix
+              (. (WebClient.) (DownloadFile url temp-name))
+              (ZipFile/ExtractToDirectory temp-name ".")
+              (File/Delete temp-name)))))
+
+(defmethod paths :gitlab
+  [{:keys [root]}
+   [head repo branch & {:keys [paths sha]}]]
+  (let [gitlab-user (namespace repo)
+        gitlab-repo (name repo)
+        prefix (str root "/" (name head) "/" gitlab-user "/" gitlab-repo "-" branch "-" sha)]
+    (concat [prefix]
+            (map #(str prefix "/" %) paths))))


### PR DESCRIPTION
close #31 

We can now add gitlab public or private deps to `project.edn`.