### PR TITLE
Add magic-modes in cli-repl args options

### DIFF
--- a/nostrand/tasks.clj
+++ b/nostrand/tasks.clj
@@ -26,6 +26,7 @@
 (defn cli-repl
   ([] (cli-repl nil))
   ([args]
+   (version)
    (repl/cli args)))
 
 (defn socket-repl [args]


### PR DESCRIPTION
Closes #39 
---

I think the only 2 relevant flags for the REPL are `*legacy-dynamic-callsites*` and `*strongly-typed-invokes*`.
I think the rest of the flags are not really useful for the REPL, should I add them all available just in case?