### PR TITLE
Fix git host deps and add nuget pack and push support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ If a file named `project.edn` is present in the current directory, it will be pa
 * `:dependencies` A vector of package coordinates your project depends on
 
 ### Dependencies
-*Support for dependencies is very new and likely buggy. Please take out issues as you encounter them.*
 
 Nostrand supports packages from Maven Central and Clojars, as well as github and NuGet. `project.edn`'s `:dependencies` key accepts a vector of package coordinates of the form `[source name version]` , where `source` is a keyword that specifies which repository to pull from, `name` is a symbol that specifies the name of the package, and `version` is a string that specifies the verison of the package. `name` and `version` will depend on the `source`.
 
@@ -127,24 +126,53 @@ For example, the [MAGIC project's](https://github.com/nasser/magic) [`project.ed
 ```
 
 #### `:github`
-Github sources clone a whole repository as a dependency. `name` takes the form `username/repository` and `version` is anything that refers to a commit, like a branch name, a tag, or a full commit hash.
+Github sources clone a whole repository as a dependency.
 
-#### `:gitlab`
-Gitlab sources clone a whole repository as a dependency. `name` takes the form `username/repository` and `version` is the branch name. The `sha` and the `project-id` must be provided as well for public and private repository. For private repository, `domain` and access `token` are required as well. Here is an example of a gitlab private dependency:
+- `name` takes the form `username/repository` and `version` is anything that refers to a commit (sha recommended).
+- You must provide both `branch` and `sha` if you want to download the zip of a specific branch.
+- For private repo, the `token` must be provided and the `sha`.
+- Be careful with GitHub personal token has they cannot be set to read only! (For your private GitHub repo, it is advised to create a dummy account with read-only access on your repos and generate the token from this dummy user.)
 
 ```clojure
-[:gitlab loic/my-lib "master"
- :paths ["src"]
- :sha "08f78dec3po452272cr2d2eb2ea85778ff2ce1d6"
- :token "xxxxxxxxxxxxx"
- :domain "dev.hello.sg"
- :project-id "777"]
+[;; public repo
+ [:github skydread1/my-public-lib "feature-1"
+  :sha "46bb12e33ae4fe118a1aa91d2985f1f2f3192366"
+  :paths ["src"]]
+ ;; private repo
+ [:github skydread1/my-private-lib "master"
+  :paths ["src"]
+  :sha "46bb12e33ae4fe118a1aa91d2985f1f2f3192367"
+  :token "xxxxxxxxxxxxx"]]
+```
+
+#### `:gitlab`
+Gitlab sources clone a whole repository as a dependency.
+
+- `name` takes the form `username/repository` and `version` is  anything that refers to a commit (sha recommended).
+- The `branch`, `sha` and the `project-id` must be provided for public and private repository.
+- For private repository, `domain` and access `token` are required as well.
+
+```clojure
+[;; public repo
+ [:gitlab skydread1/my-public-lib "master"
+  :paths ["src"]
+  :sha "46bb12e33ae4fe118a1aa91d2985f1f2f3192366"
+  :project-id "777"]
+ ;; private repo
+ [:gitlab skydread1/my-private-lib "master"
+  :paths ["src"]
+  :sha "46bb12e33ae4fe118a1aa91d2985f1f2f3192367"
+  :token "xxxxxxxxxxxxx"
+  :domain "dev.hello.sg"
+  :project-id "888"]]
 ```
 
 The root of the repository is the only directory added to the load path by default, but you can specify subdirectories by adding `:paths` followed by a vector of strings to the coordinate.
 
 #### `:nuget`
 `name` and `version` are the same as you would pass in to `nuget install name -Version version`.
+
+You can pack and push packages easily with the convenient function `tasks/nuget-push`.
 
 #### `:maven`
 Behaves as in Leiningen. Note that many Clojure packages will not work on ClojurCLR without modification, as they may reference Java classes that are not present on the CLR.

--- a/nostrand/deps/github.clj
+++ b/nostrand/deps/github.clj
@@ -4,27 +4,67 @@
 (ns nostrand.deps.github
   (:import [System.IO.Compression ZipFile]
            [System.IO Directory File]
-           [System.Net WebClient])
+           [System.Net WebClient HttpRequestHeader])
   (:require [nostrand.deps :refer [acquire! paths assemblies]]
             [nostrand.deps.shell :refer [sh in-dir]]))
 
+(defn build-uri
+  "Create the proper uri to fetch the remote lib."
+  [branch token user repo sha]
+  (cond
+    (and token user repo sha) ;; private repo
+    (str "https://api.github.com/repos/" user "/" repo "/zipball/" sha)
+
+    (and user repo branch sha) ;; public repo via sha
+    (str "https://github.com/" user "/" repo "/archive/" sha ".zip")
+
+    (and user repo branch) ;; public repo via default branch
+    (str "https://github.com/" user "/" repo "/archive/" branch ".zip")
+
+    :else
+    (throw (ex-info "Missing some GitHab API parameters:"
+                    (if token
+                      {:scope :private :user user :repo repo :branch branch :sha sha}
+                      {:scope :public :user user :repo repo :branch branch :sha sha})))))
+
+(defn archive-repo-format
+  "Returns the expected repo name in the archive. "
+  [github-repo github-user branch sha token]
+  (cond
+    token
+    (str github-user "-" github-repo "-" sha)
+    sha
+    (str github-repo "-" sha)
+    :else
+    (str github-repo "-" branch)))
+
 (defmethod acquire! :github
-  [{:keys [root] :as opts}
-   [head repo branch & coord-opts]]
-  (let [github-user (namespace repo)
-        github-repo (name repo)
-        url (str "https://github.com/" github-user "/" github-repo "/archive/" branch ".zip")
-        prefix (str root "/" (name head) "/" github-user)
-        temp-name (str (gensym (str github-user "-" github-repo)) ".zip")]
-    (when-not (Directory/Exists (str prefix "/" github-repo "-" branch))
+  [{:keys [root]}
+   [head repo branch & {:keys [sha token]}]]
+  (let [github-user       (namespace repo)
+        github-repo       (name repo)
+        url               (build-uri branch token github-user github-repo sha)
+        prefix            (str root "/" (name head) "/" github-user)
+        temp-name         (str (gensym (str github-user "-" github-repo)) ".zip")
+        repo-mame-final   (str github-repo "-" branch)
+        repo-name-fetched (archive-repo-format github-repo github-user branch sha token)
+        web-client        (WebClient.)]
+    (println "Downloading GitHub Repo: " repo)
+    (when-not (Directory/Exists (str prefix "/" repo-mame-final))
       (in-dir prefix
-              (. (WebClient.) (DownloadFile url temp-name))
+              (when token
+                (. (.Headers web-client) (Add "User-Agent" "My App"))
+                (. (.Headers web-client) (Add HttpRequestHeader/Authorization (str "token " token))))
+              (. web-client (DownloadFile url temp-name))
               (ZipFile/ExtractToDirectory temp-name ".")
-              (File/Delete temp-name)))))
+              (File/Delete temp-name)
+              (when-not (= repo-name-fetched repo-mame-final)
+                (Directory/Move (str "./" repo-name-fetched)
+                                (str "./" repo-mame-final)))))))
 
 (defmethod paths :github
-  [{:keys [root] :as opts}
-   [head repo branch & {:keys [paths] :as coord-opts}]]
+  [{:keys [root]}
+   [head repo branch & {:keys [paths]}]]
   (let [github-user (namespace repo)
         github-repo (name repo)
         prefix (str root "/" (name head) "/" github-user "/" github-repo "-" branch)]

--- a/nostrand/deps/gitlab.clj
+++ b/nostrand/deps/gitlab.clj
@@ -10,32 +10,51 @@
 
 (defn build-uri
   "Create the proper uri to fetch the remote lib."
-  [branch token domain project-id]
-  (if token
-    ;; private project : needs token access and domain
-    (str "https://" domain "/api/v4/projects/" project-id "/repository/archive.zip?ref=" branch "&access_token=" token)
-    ;; public project
-    (str "https://gitlab.com/api/v4/projects/" project-id "/repository/archive.zip?ref=" branch)))
+  [token domain project-id sha]
+  (cond
+    (and token domain project-id sha) ;; private repo
+    (str "https://" domain "/api/v4/projects/" project-id "/repository/archive.zip?sha=" sha "&access_token=" token)
+
+    (and project-id sha) ;; public repo
+    (str "https://gitlab.com/api/v4/projects/" project-id "/repository/archive.zip?sha=" sha)
+
+    :else
+    (throw (ex-info "Missing some GitLab API parameters: "
+                    (if token
+                      {:scope :private :domain domain :project-id project-id :sha sha}
+                      {:scope :public :project-id project-id :sha sha})))))
+
+(defn archive-repo-format
+  "Returns the expected repo name in the archive."
+  [gitlab-repo branch sha]
+  (if sha
+    (str gitlab-repo "-" sha "-" sha)
+    (str gitlab-repo "-" branch "-" sha)))
 
 (defmethod acquire! :gitlab
-  [{:keys [root] :as opts}
+  [{:keys [root]}
    [head repo branch & {:keys [sha token domain project-id]}]]
-  (let [gitlab-user (namespace repo)
-        gitlab-repo (name repo)
-        url (build-uri branch token domain project-id)
-        prefix (str root "/" (name head) "/" gitlab-user)
-        temp-name (str (gensym (str gitlab-user "-" gitlab-repo)) ".zip")]
-    (when-not (Directory/Exists (str prefix "/" gitlab-repo "-" branch "-" sha))
+  (let [gitlab-user       (namespace repo)
+        gitlab-repo       (name repo)
+        url               (build-uri token domain project-id sha)
+        prefix            (str root "/" (name head) "/" gitlab-user)
+        temp-name         (str (gensym (str gitlab-user "-" gitlab-repo)) ".zip")
+        repo-mame-final   (str gitlab-repo "-" branch)
+        repo-name-fetched (archive-repo-format gitlab-repo branch sha)]
+    (println "Downloading GitLab Repo: " repo)
+    (when-not (Directory/Exists (str prefix "/" repo-mame-final))
       (in-dir prefix
               (. (WebClient.) (DownloadFile url temp-name))
               (ZipFile/ExtractToDirectory temp-name ".")
-              (File/Delete temp-name)))))
+              (File/Delete temp-name)
+              (Directory/Move (str "./" repo-name-fetched)
+                              (str "./" repo-mame-final))))))
 
 (defmethod paths :gitlab
   [{:keys [root]}
-   [head repo branch & {:keys [paths sha]}]]
+   [head repo branch & {:keys [paths]}]]
   (let [gitlab-user (namespace repo)
         gitlab-repo (name repo)
-        prefix (str root "/" (name head) "/" gitlab-user "/" gitlab-repo "-" branch "-" sha)]
+        prefix (str root "/" (name head) "/" gitlab-user "/" gitlab-repo "-" branch)]
     (concat [prefix]
             (map #(str prefix "/" %) paths))))

--- a/nostrand/tasks.clj
+++ b/nostrand/tasks.clj
@@ -1,13 +1,14 @@
 (ns
-  ^{:author "Ramsey Nasser"
-    :doc "Built in nostrand tasks, available from the command line as unqualified functions"}
-  nostrand.tasks
+    ^{:author "Ramsey Nasser"
+      :doc    "Built in nostrand tasks, available from the command line as unqualified functions"}
+    nostrand.tasks
   (:import
-    [Nostrand Nostrand]
-    [System.IO Directory]
-    [System.Threading Thread ThreadStart]
-    [System.Reflection AssemblyInformationalVersionAttribute])
+   [Nostrand Nostrand]
+   [System.IO Directory]
+   [System.Threading Thread ThreadStart]
+   [System.Reflection AssemblyInformationalVersionAttribute])
   (:require [nostrand.repl :as repl]
+            [nostrand.deps.nuget :as nuget]
             [clojure.string :as string]
             [clojure.core.server :as clj-server]
             clojure.repl))
@@ -68,3 +69,14 @@
     (println "done ")
     (println "Started socket repl with Options: " opts)
     (repl)))
+
+(defn nuget-push
+  "Pack and Push NuGet Package to git host repo.
+  - `git-host`     : 'github' or 'gitlab'
+  - `with-build?`  : true by default
+  - `configuration`: 'Release' by default."
+  [git-host-type with-build? configuration]
+  (binding [*compile-path* "build"]
+    (nuget/pack-and-push-nuget git-host-type
+                               :with-build? with-build?
+                               :configuration configuration)))


### PR DESCRIPTION
Closes #37 
---
- `sha` parameter is now used instead of obsolete `ref` parameter in the built `gitlab` url.
- `sha` and `branch` value case handled
-  Final deps repo name is always using the branch name only for clarity such as: `[repo]-[branch]`


Closes #34
---
- Private `github` dep supported using GitHub token
- Better error handling for missing or wrong parameters for `gitlab` and `github` API calls.

Closes #42
---
- We can now pack and push NuGet packages to a GitHub/GitLab Package registries.
- Tested with GitHub and GitLab.
- Add `task/nuget-push` convenient function to pack and push in one command.